### PR TITLE
fix: nextjs version sintaxis

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "14.2.10",
+    "next": ">=14.2.10",
     "react": "^18",
     "react-dom": "^18",
     "react-icons": "^5.3.0",


### PR DESCRIPTION
### Changes

Fix nextjs version format , instead of `14.2.10` use `>=14.2.10`

---

N/A
